### PR TITLE
BUG Prevent akismetprocessor crashing on dev/build when schema changes

### DIFF
--- a/code/config/AkismetProcessor.php
+++ b/code/config/AkismetProcessor.php
@@ -11,16 +11,47 @@ class AkismetProcessor implements RequestFilter {
 
 	public function preRequest(SS_HTTPRequest $request, Session $session, DataModel $model) {
 		// Skip if database isn't ready
-		if(!DB::isActive() || !DB::getConn()->hasField('SiteConfig', 'AkismetKey')) return;
+		if(!$this->isDBReady()) {
+			return;
+		}
 
 		// Skip if SiteConfig doesn't have this extension
-		if(!SiteConfig::has_extension('AkismetConfig')) return;
+		if(!SiteConfig::has_extension('AkismetConfig')) {
+			return;
+		}
 
 		// Check if key exists
 		$akismetKey = SiteConfig::current_site_config()->AkismetKey;
 		if($akismetKey) {
 			AkismetSpamProtector::set_api_key($akismetKey);
 		}
+	}
+
+	/**
+	 * Make sure the DB is ready before accessing siteconfig db field
+	 *
+	 * @return bool
+	 */
+	protected function isDBReady() {
+		if(!DB::isActive()) {
+			return false;
+		}
+
+		// Require table
+		if(!DB::getConn()->hasTable('SiteConfig')) {
+			return false;
+		}
+
+		// Ensure siteconfig has all fields necessary
+		$dbFields = DB::fieldList('SiteConfig');
+		if(empty($dbFields)) {
+			return false;
+		}
+
+		// Ensure that SiteConfig has all fields
+		$objFields = DataObject::database_fields('SiteConfig', false);
+		$missingFields = array_diff_key($objFields, $dbFields);
+		return empty($missingFields);
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"issues": "https://github.com/silverstripe/silverstripe-akismet/issues"
 	},
 	"require": {
+		"silverstripe/cms": "~3.1",
 		"silverstripe/framework": "~3.1",
 		"tijsverkoyen/akismet": "1.1.0",
 		"silverstripe/spamprotection": "~2.0"


### PR DESCRIPTION
Otherwise, dev/build is impossible to run without manually fixing the DB schema.
