### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/silverstripe/silverstripe-akismet/issues"
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/cms": "^4.0",
         "tijsverkoyen/akismet": "1.1.0",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219